### PR TITLE
feat(lockdrop): add contracts

### DIFF
--- a/contracts/lock/.gitignore
+++ b/contracts/lock/.gitignore
@@ -1,0 +1,9 @@
+# Ignore build artifacts from the local tests sub-crate.
+/target/
+
+# Ignore backup files creates by cargo fmt.
+**/*.rs.bk
+
+# Remove Cargo.lock when creating an executable, leave it for libraries
+# More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
+Cargo.lock

--- a/contracts/lock/Cargo.toml
+++ b/contracts/lock/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "lock"
+version = "0.1.0"
+authors = ["[your_name] <[your_email]>"]
+edition = "2018"
+
+[dependencies]
+ink_primitives = { version = "3.0.0-rc4", default-features = false }
+ink_metadata = { version = "3.0.0-rc4", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0.0-rc4", default-features = false }
+ink_storage = { version = "3.0.0-rc4", default-features = false }
+ink_lang = { version = "3.0.0-rc4", default-features = false }
+
+scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
+scale-info = { version = "0.6.0", default-features = false, features = ["derive"], optional = true }
+
+[lib]
+name = "lock"
+path = "lib.rs"
+crate-type = [
+	# Used for normal contract Wasm blobs.
+	"cdylib",
+    # Used for ABI generation. Required for contracts to be included in other contracts.
+    "rlib",
+]
+
+[features]
+default = ["std"]
+std = [
+    "ink_metadata/std",
+    "ink_env/std",
+    "ink_storage/std",
+    "ink_primitives/std",
+    "scale/std",
+    "scale-info/std",
+]
+ink-as-dependency = []

--- a/contracts/lock/lib.rs
+++ b/contracts/lock/lib.rs
@@ -1,0 +1,53 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub use self::lock::Lock;
+use ink_lang as ink;
+
+#[ink::contract]
+mod lock {
+    #[ink(storage)]
+    pub struct Lock {
+        owner: AccountId,
+        unlock_after: Timestamp,
+    }
+
+    impl Lock {
+        #[ink(constructor)]
+        pub fn new(owner: AccountId, unlock_after: Timestamp) -> Self {
+            Self {
+                owner,
+                unlock_after,
+            }
+        }
+
+        #[ink(message, payable)]
+        pub fn unlock(&mut self) {
+            let now = self.env().block_timestamp();
+
+            // check if the lock can be opened yet
+            assert!(now > self.unlock_after);
+
+            let caller = self.env().caller();
+
+            // check if the caller is the owner
+            assert_eq!(caller, self.owner);
+
+            // send all of your balance to the owner
+            match self.env().transfer(caller, self.env().balance()) {
+                Err(ink_env::Error::BelowSubsistenceThreshold) => {
+                    panic!(
+                        "requested transfer would have brought contract\
+                        below subsistence threshold!"
+                    )
+                }
+                Err(_) => panic!("transfer failed!"),
+                Ok(_) => {}
+            }
+        }
+
+        #[ink(message)]
+        pub fn balance(&self) -> Balance {
+            Self::env().balance()
+        }
+    }
+}

--- a/contracts/lockdrop/.gitignore
+++ b/contracts/lockdrop/.gitignore
@@ -1,0 +1,9 @@
+# Ignore build artifacts from the local tests sub-crate.
+/target/
+
+# Ignore backup files creates by cargo fmt.
+**/*.rs.bk
+
+# Remove Cargo.lock when creating an executable, leave it for libraries
+# More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
+Cargo.lock

--- a/contracts/lockdrop/Cargo.toml
+++ b/contracts/lockdrop/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "lockdrop"
+version = "0.1.0"
+authors = ["[your_name] <[your_email]>"]
+edition = "2018"
+
+[dependencies]
+ink_primitives = { version = "3.0.0-rc3", default-features = false }
+ink_metadata = { version = "3.0.0-rc3", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0.0-rc3", default-features = false }
+ink_storage = { version = "3.0.0-rc3", default-features = false }
+ink_lang = { version = "3.0.0-rc3", default-features = false }
+
+scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
+scale-info = { version = "0.6.0", default-features = false, features = ["derive"], optional = true }
+
+lock = { path = "../lock" , version="0.1.0", default-features = false, features = ["ink-as-dependency"] }
+
+[lib]
+name = "lockdrop"
+path = "lib.rs"
+crate-type = [
+	# Used for normal contract Wasm blobs.
+	"cdylib",
+]
+
+[features]
+default = ["std"]
+std = [
+    "ink_metadata/std",
+    "ink_env/std",
+    "ink_storage/std",
+    "ink_primitives/std",
+    "scale/std",
+    "scale-info/std",
+    "lock/std",
+]
+ink-as-dependency = []

--- a/contracts/lockdrop/lib.rs
+++ b/contracts/lockdrop/lib.rs
@@ -1,0 +1,42 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use ink_lang as ink;
+
+#[ink::contract]
+mod lockdrop {
+    use lock::Lock;
+
+    #[ink(storage)]
+    pub struct Lockdrop {
+        lock_contract_code_hash: Hash,
+    }
+
+    impl Lockdrop {
+        #[ink(constructor)]
+        pub fn new(lock_contract_code_hash: Hash) -> Self {
+            Self {
+                lock_contract_code_hash,
+            }
+        }
+
+        #[ink(message, payable)]
+        pub fn lock(&mut self) {
+            let balance_to_be_locked = self.env().transferred_balance();
+
+            let now = self.env().block_timestamp();
+            let unlock_after = now + 5;
+
+            let salt = 1u32.to_le_bytes();
+
+            let lock = Lock::new(self.env().caller(), unlock_after)
+                .endowment(balance_to_be_locked)
+                .code_hash(self.lock_contract_code_hash.clone())
+                .salt_bytes(salt)
+                .instantiate()
+                .expect("failed at instantiating the `Lock` contract");
+
+            // check if balance has been locked correctly
+            assert!(lock.balance() >= balance_to_be_locked);
+        }
+    }
+}

--- a/tests/erc20.test.ts
+++ b/tests/erc20.test.ts
@@ -11,10 +11,10 @@ describe("ERC20", () => {
   });
 
   async function setup({
-    tokenName = 'Atomikoin',
-    tokenSymbol = 'ATK',
-    tokenInitialSupply = 1000
-  } = {}) {
+                         tokenName = 'Atomikoin',
+                         tokenSymbol = 'ATK',
+                         tokenInitialSupply = 1000
+                       } = {}) {
     await api.isReady;
     const signerAddresses = await getAddresses();
     const Alice = signerAddresses[0];
@@ -22,6 +22,20 @@ describe("ERC20", () => {
     const contractFactory = await getContractFactory("erc20", sender.address);
     const contract = await contractFactory.deploy("new", tokenName, tokenSymbol, tokenInitialSupply);
     const abi = artifacts.readArtifact("erc20");
+    const receiver = await getRandomSigner();
+
+    return { sender, contractFactory, contract, abi, receiver, Alice };
+  }
+
+  async function setupLockdrop() {
+    await api.isReady;
+    const signerAddresses = await getAddresses();
+    const Alice = signerAddresses[0];
+    const sender = await getRandomSigner(Alice, "10000 UNIT");
+    const contractFactoryLock = await getContractFactory("lock", sender.address);
+    const contractFactory = await getContractFactory("lockdrop", sender.address);
+    const contract = await contractFactory.deploy("new", );
+    const abi = artifacts.readArtifact("lockdrop");
     const receiver = await getRandomSigner();
 
     return { sender, contractFactory, contract, abi, receiver, Alice };
@@ -110,7 +124,7 @@ describe("ERC20", () => {
     expect(balanceOfResult.output).to.equal(tokenInitialSupply)
   });
 
-  it.only("Trading pair", async () => {
+  it("Trading pair", async () => {
     const tokenAParams = { tokenName: 'token a', tokenSymbol: 'TKA', tokenInitialSupply: 1234 };
     const tokenA = await setup(tokenAParams);
 
@@ -126,6 +140,11 @@ describe("ERC20", () => {
     const [tokenASymbol, tokenBSymbol] = symbolResult.output?.toHuman() as Array<String>;
     expect(tokenASymbol).to.equal(tokenAParams.tokenSymbol);
     expect(tokenBSymbol).to.equal(tokenBParams.tokenSymbol);
+  });
 
-  })
+  it.only("Lockdrop", async () => {
+    const { contract, Alice, sender } = await setupLockdrop();
+
+    await contract.tx.lock(7);
+  });
 });


### PR DESCRIPTION
Introduce two smart contracts: `Lockdrop`, and `Lock`. They are meant to work exactly the same as this Solitiy implementation: https://etherscan.io/address/0xa4803f17607b7cdc3dc579083d9a14089e87502b#code